### PR TITLE
Store address fields (to, from, cc, bcc, reply-to) as comma separated strings

### DIFF
--- a/lib/mailhopper/queue.rb
+++ b/lib/mailhopper/queue.rb
@@ -5,14 +5,20 @@ module Mailhopper
 
     def deliver!(mail)
       Base.email_class.create({
-        :to_address => mail.to.to_s,
-        :from_address => mail.from.to_s,
-        :cc_address => mail.cc.to_s,
-        :bcc_address => mail.bcc.to_s,
-        :reply_to_address => mail.reply_to.to_s,
-        :subject => mail.subject,
-        :content => mail.to_s
+        :to_address       => address_to_s(mail.to),
+        :from_address     => address_to_s(mail.from),
+        :cc_address       => address_to_s(mail.cc),
+        :bcc_address      => address_to_s(mail.bcc),
+        :reply_to_address => address_to_s(mail.reply_to),
+        :subject          => mail.subject,
+        :content          => mail.to_s
       })
+    end
+
+    private
+
+    def address_to_s(field)
+      field.join(',') if field
     end
   end
 end

--- a/test/unit/email_test.rb
+++ b/test/unit/email_test.rb
@@ -28,12 +28,13 @@ class EmailTest < ActiveSupport::TestCase
       assert_equal Mailhopper::Email.count, 1
 
       email = Mailhopper::Email.first
-      assert_equal email.from_address, headers[:from]
-      assert_equal email.to_address, headers[:to]
-      assert_equal email.cc_address, headers[:cc]
-      assert_equal email.bcc_address, headers[:bcc]
-      assert_equal email.reply_to_address, headers[:reply_to]
-      assert_equal email.subject, headers[:subject]
+
+      assert_equal headers[:from],      email.from_address
+      assert_equal headers[:to],        email.to_address
+      assert_equal headers[:cc],        email.cc_address
+      assert_equal headers[:bcc],       email.bcc_address
+      assert_equal headers[:reply_to],  email.reply_to_address
+      assert_equal headers[:subject],   email.subject
 
       # Email content will include headers as well as content
       assert email.content.include?(content)


### PR DESCRIPTION
There is a problem with the current method of storing and sending emails. The existing tests highlights this problem when run:

```
  1) Failure:
test: An email should be generated when mail is sent. (EmailTest) [/mailhopper/test/unit/email_test.rb:31]:
<"[\"from@example.com\"]"> expected but was
<"from@example.com">.
```

Most address fields are not impacted because Email#send! uses Email#content to build a new Mail object. But since the bcc field isn't in Email#content, a separate line ([Line 10 of email.rb](https://github.com/cerebris/mailhopper/blob/master/app/models/mailhopper/email.rb#L10)) sets the bcc attribute. But since it was storred in the format `"[\"css@example.com\"]"`, the email gets sent to `[css@example.com]` which isn't a valid address.

This patch fixes that problem by saving all address fields as comma separated strings. I've also flipped the arguments on assert_equal to so failed tests read correctly (as opposed to the above test output which is backwards).

---

Thanks for much for releasing this and mailhopper_delayed. Together they make sending emails so much better in Rails. If there is anything you'd like me to change or fix in this pull request just let me know. 
