### PR TITLE
Destination address fields should default to text type columns

### DIFF
--- a/lib/generators/mailhopper/templates/migrations/create_emails.rb
+++ b/lib/generators/mailhopper/templates/migrations/create_emails.rb
@@ -4,12 +4,15 @@ class CreateEmails < ActiveRecord::Migration
   def self.up
     create_table :emails do |t|
       t.string :from_address, :null => false
-      t.string :to_address,
+
+      t.string :reply_to_address,
+               :subject
+
+      t.text   :to_address,
                :cc_address,
                :bcc_address,
-               :reply_to_address,
-               :subject
-      t.text :content
+               :content
+
       t.datetime :sent_at
       t.timestamps
     end


### PR DESCRIPTION
The current migration template has to, cc, and bcc address fields as strings. It is possible to have many recipients which will exceed the character limit on a string field.

Obviously users can change the migration after it is created, but I think making those address fields text by default is better.
