### PR TITLE
Removed trailing comma (,) after :bcc_address in migration

### DIFF
--- a/lib/generators/mailhopper/templates/migrations/create_emails.rb
+++ b/lib/generators/mailhopper/templates/migrations/create_emails.rb
@@ -14,7 +14,7 @@ class CreateEmails < ActiveRecord::Migration
 
       t.text   :to_address,
                :cc_address,
-               :bcc_address,
+               :bcc_address
 
       t.text   :content
 


### PR DESCRIPTION
Fixes a syntax error in the generated migration.

I installed the gem, migrated the database and got:

```
/db/migrate/20110918034612_create_emails.rb:19: syntax error, unexpected tSYMBEG, expecting keyword_end
     t.text   :content 
```

Removing the extra comma fixed this.
